### PR TITLE
Update: remove install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "build:docs": "documentation build --document-exported src/** -f html --o docs",
     "build": "npm run build:node && npm run build:types",
     "prepublishOnly": "npm run build && npm run build:umd && npm test",
-    "install": "npm run build",
     "precommit": "lint-staged",
     "start": "flow-copy-source --watch --verbose src lib & babel --watch --out-dir lib src"
   },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "watchify": "^3.11.1"
   },
   "scripts": {
+    "pretest": "npm run build",
     "test": "npm run test:flow && npm run test:tape",
     "test:tape": "karma start --single-run",
     "test:watch": "karma start",


### PR DESCRIPTION
This PR removes the `install` script from package.json scripts. This fixes npm installs since the lib is already generated with the `prepublishOnly` script. 
If we need to have keep an _install from github_ option I suggest to push the `lib` dir.

I've added a `pretest` script which runs `npm run build`. This will generate the `/lib` dir required for the tests. We can use it this way or we can modify the travis setup so only travis have to run the build before the tests. And we can update the readme mentioning that for testing you should run the build script first.

What do you think?